### PR TITLE
priv-sbom:Makefile:add self-bootstrapping target

### DIFF
--- a/privateSBOMExchange/.gitignore
+++ b/privateSBOMExchange/.gitignore
@@ -1,1 +1,2 @@
 test/data/*
+virtualenv

--- a/privateSBOMExchange/Makefile
+++ b/privateSBOMExchange/Makefile
@@ -1,7 +1,8 @@
 init:
-    pip install -r requirements.txt
+	bash ./bootstrap.sh
+	@echo "run source virtualenv/bin/activate to run the other targets"
 
 test:
-    py.test tests
+	py.test tests
 
 .PHONY: init test

--- a/privateSBOMExchange/bootstrap.sh
+++ b/privateSBOMExchange/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#set -x
+
+if [ ! -e virtualenv ]
+then
+    echo "didn't identify a venv"
+    python -m venv virtualenv
+else
+    echo "Using existing venv"
+fi
+
+source virtualenv/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
Currently, the Makefile does not allow to initialize the environment in systems that disapprove/discourage runing pip at "system level". Instead, we need to use a virutalenv. Add a "bootstrap script" and update the init target to run that instead.