### PR TITLE
Add config file infra for CLI and testing

### DIFF
--- a/privateSBOMExchange/README.md
+++ b/privateSBOMExchange/README.md
@@ -1,5 +1,13 @@
 # PETRA
 
+In this doc:
+
+[Dir contents]: #contents
+[Petra setup]: #setup
+[Using Petra]: #petra-usage
+
+## Contents
+
 This directory contains the two modules needed to run the Petra system (currently under submission).
 
 The following files are currently in here
@@ -13,33 +21,68 @@ The following files are currently in here
 Of which, `docs` contains documentation, and Makefile, pyproject.toml and
 requirements.txt, bootstrap.sh support setting up the project.
 
-Make sure you have a virtual environment set up (e.g., by making make init) or
-installing the requirements on a virtual environment using `pip install -r
-requirements.txt`.
+## Setup
 
-src contains the code needed for this scrpit, and it is split into two modules: petra and cpabe.
+You can set up a virtual environment in two ways:
 
-## cpabe
+```
+make init
+```
+
+or
+
+```
+virtualenv <venv name>
+source <venv name>/bin/activate
+pip install -r requirements.txt
+```
+
+`/src` contains the code needed for this script, and it is split into two modules: petra and cpabe.
+
+### cpabe
 
 cpabe is the python bindings for the rust crate rabe, this is needed to support CP-abe functionality.
+
 Before you run any other code, make sure that these bindings are built by issuing:
 
 ```
-maturin develop
+sudo apt install rustc cargo
+cd cpabe
 
+maturin develop
 ```
 
 This will build the rust code, as well as install an editable version of the
 python bindings into the current virtual environment.
 
-## petra
+### petra
 
-Petra is the main system. If cpabe is installed, you should be able to run things by running the test files under `scripts`.
+Petra is the main system. If cpabe is installed, you should be able to
+install the petra package:
+
+```
+cd petra
+pip install -e .
+```
+
+### Optional: SBOM datasets
+
+The final setup step pulls SBOM datasets from linked repos:
+
+```
+git submodule update --init
+```
+
+## Petra Usage
+
+### Tests
+
+After the setup, you should be able to run the Petra CLI by running the test files under `/tests`.
 
 For example:
 
 ```
-python scrpts/Redactor.py
+python tests/test_models.py
 ```
 
 Should showcase an encryption and selective decription of target sbom --- make

--- a/privateSBOMExchange/README.md
+++ b/privateSBOMExchange/README.md
@@ -75,6 +75,23 @@ git submodule update --init
 
 ## Petra Usage
 
+### Configuration
+
+We provide a simple configuration template for Petra in `config/petra.conf.template`. To provide your own configuration,
+point the Petra CLI to your file:
+
+```
+from petra.lib.util import config.Config
+
+conf = Config(<path to my config>)
+```
+
+**TODO**: Pass config file path as CLI arg.
+
+We also provide the following example configurations:
+
+* `config/bom-only.conf`: a short list of SBOMs to ingest into Petra
+
 ### Tests
 
 After the setup, you should be able to run the Petra CLI by running the test files under `/tests`.

--- a/privateSBOMExchange/README.md
+++ b/privateSBOMExchange/README.md
@@ -61,7 +61,7 @@ Petra is the main system. If cpabe is installed, you should be able to
 install the petra package:
 
 ```
-cd petra
+cd privateSBOMExchange
 pip install -e .
 ```
 
@@ -70,6 +70,7 @@ pip install -e .
 The final setup step pulls SBOM datasets from linked repos:
 
 ```
+cd SBOMCtl
 git submodule update --init
 ```
 

--- a/privateSBOMExchange/config/bom-only.conf
+++ b/privateSBOMExchange/config/bom-only.conf
@@ -1,0 +1,2 @@
+[sbom]
+files = ["../sbom_data/bom-shelter/in-the-wild/spdx/julia.spdx.json"]

--- a/privateSBOMExchange/config/petra.conf.template
+++ b/privateSBOMExchange/config/petra.conf.template
@@ -1,0 +1,11 @@
+# SBOM and CP-ABE information is optional
+
+[sbom]
+files = []
+
+[cp-abe]
+# the only requirement is that either both keys
+# or neither must be specified
+master-key = ""
+public-key = ""
+policy = ""

--- a/privateSBOMExchange/requirements.txt
+++ b/privateSBOMExchange/requirements.txt
@@ -1,3 +1,4 @@
+pip
 beartype==0.18.5
 boolean.py==4.0
 click==8.1.7

--- a/privateSBOMExchange/src/petra/lib/util/config.py
+++ b/privateSBOMExchange/src/petra/lib/util/config.py
@@ -1,0 +1,96 @@
+import tomli
+
+class Config:
+    """
+    Represents a Petra configuration object.
+    """
+    
+    def __init__(self, file_path: str) -> None:
+        """ Parses a TOML-formatted config file
+            and populates the underlying config dict.
+        """
+
+        self.config_dict = dict()
+        self.sbom_files = []
+        self.cpabe_key_files = dict()
+        self.cpabe_mk = ""
+        self.cpabe_pk = ""
+        self.cpabe_policy = ""
+
+        # we may want to catch some exceptions here
+        with open(file_path, "rb") as f:
+            self.config_dict = tomli.load(f)
+
+        # store the SBOM file names, if any
+        sbom_dict = self.config_dict.get("sbom")
+
+        if sbom_dict != None:
+            self.sbom_files = sbom_dict.get("files")
+
+        # store the CP-ABE info, if any
+        cpabe_dict = self.config_dict.get("cp-abe")
+
+        if cpabe_dict != None:
+            # get the CP-ABE keys and policy, if any
+
+            # get the key paths
+            master_file_path = cpabe_dict.get("master-key")
+            public_file_path = cpabe_dict.get("public-key")
+
+            # only read them in if both are specified.
+            # otherwise, raise an error
+            if master_file_path != None and public_file_path != None:
+                # expect the files to be encoded as a string
+                with open(master_file_path, "r") as f:
+                    self.cpabe_mk = f.read()
+                
+                with open(public_file_path, "r") as f:
+                    self.cpabe_pk = f.read()
+            elif master_file_path == None and public_file_path == None:
+                # it's ok to pass when neither is specified.
+                # this should trigger Petra to generate the keys
+                pass
+            else:
+                # raise an error since we expect both master and
+                # public keys to be specified
+                raise ValueError("Master or public key file path missing")
+
+            # finally, get the policy file, if any
+            policy_file_path = cpabe_dict.get("policy")
+
+            if policy_file_path != None:
+                # expect the file to be encoded as a string
+                with open(policy_file_path, "r") as f:
+                    self.cpabe_policy = f.read()
+
+    def get_sbom_files(self) -> list:
+        """ Returns the list of SBOM files to read into
+            Petra, or an empty list if none were specified
+            in the config.
+        """
+        return self.sbom_files
+
+    def get_cpabe_key_files(self) -> dict:
+        """ Returns the dict containing the file paths
+            to the Petra CP-ABE keys, or None if key files
+            weren't specified in the config.
+        """
+        return self.cpabe_key_files
+
+    def get_cpabe_master_key(self) -> str:
+        """ Returns the CP-ABE master key as a string.
+            May be empty.
+        """
+        return self.cpabe_mk
+
+    def get_cpabe_public_key(self) -> str:
+        """ Returns the CP-ABE public key as a string.
+            May be empty.
+        """
+        return self.cpabe_pk
+
+    def get_cpabe_public_key(self) -> str:
+        """ Returns the CP-ABE policy as a string.
+            May be empty.
+        """
+        return self.cpabe_policy

--- a/privateSBOMExchange/tests/test_models.py
+++ b/privateSBOMExchange/tests/test_models.py
@@ -2,11 +2,18 @@ import configparser
 from lib4sbom.parser import SBOMParser
 
 from petra.lib.models import *
+from petra.lib.util.config import Config
+
 """This tests inserting a sbom as tree ,assuming Non of the dependencies has its own sbom 
 """
+
+# get the SBOM from the basic config
+conf = Config("config/bom-only.conf")
+bom_file = conf.get_sbom_files()[0]
+
 # Parse SPDX data into a Document object
 SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file("../sbom_data/bom-shelter/in-the-wild/spdx/julia.spdx.json")   
+SBOM_parser.parse_file(bom_file)   
 #SBOM_parser.parse_file("simple_sbom.json")
 # Build the tree and compute the root hash
 sbom=SBOM_parser.sbom


### PR DESCRIPTION
This PR adds a super basic toml-based config file API for use in the CLI and tests.