### PR TITLE
Add tree to model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 **/*priv_key
 #Ignore database
 *.db
+build/
+__pycache__
+*.egg-info

--- a/privateSBOMExchange/src/petra/lib/models/__init__.py
+++ b/privateSBOMExchange/src/petra/lib/models/__init__.py
@@ -207,7 +207,7 @@ class MerkleVisitor:
             The computed hash of the SBOM node data and its children.
         """
         children_hashes = b''.join(child.accept(self) for child in node.children)
-        data_to_hash = (node.purl).encode() + children_hashes
+        data_to_hash = (f"{node.complex_type}{node.purl}").encode() + children_hashes
         node.hash=hashlib.sha256(data_to_hash).digest()
         return node.hash 
 

--- a/privateSBOMExchange/src/petra/lib/models/__init__.py
+++ b/privateSBOMExchange/src/petra/lib/models/__init__.py
@@ -506,6 +506,6 @@ def build_sbom_tree(parser:SBOMParser):
 
     sbom_name=parser.get_document()["name"]
     pURL=""
-    root = SbomNode(sbom_name,pURL,leaves + root_children)
+    root = SbomNode(sbom_name,pURL, root_children)
     #ToDo store sign (root) , hash (root), and the tree in the database
     return root

--- a/privateSBOMExchange/tests/test_models.py
+++ b/privateSBOMExchange/tests/test_models.py
@@ -31,4 +31,8 @@ merkle_visitor = MerkleVisitor()
 merkle_root_hash = sbom_tree.accept(merkle_visitor)
 # Convert the root hash to a hexadecimal representation for display
 merkle_root_hash_hex = merkle_root_hash.hex()
+
+print("Printing hashed and encrypted SBOM tree")
+sbom_tree.accept(print_visitor)
+
 print("Merkle Root Hash for SBOM:", merkle_root_hash_hex)


### PR DESCRIPTION
Changes to complex node:
- Add type data field to distinguish between different types of complex nodes
- handle policy for complex type node
- added placeholders for node data fields and encrypted data.
Added document information as complex node such that the root only have complex nodes as children

Fixes #23 