### PR TITLE
Use commitments instead of hashes for content sameness verification

### DIFF
--- a/privateSBOMExchange/src/petra/lib/crypto.py
+++ b/privateSBOMExchange/src/petra/lib/crypto.py
@@ -18,13 +18,13 @@ class Commitment:
     """ Implements a simple cryptographic commitment."""
     def __init__(self, to_commit: bytes) -> None:
         self.salt = get_salt()
-        self.value = digest(self.salt + to_commit)
+        self.value = digest(self.serialize(to_commit))
 
     def serialize(self, data: bytes) -> bytes:
         return self.salt + data
 
-    def verify(self, opening: bytes) -> bool:
-        return self.value == digest(self.serialize(opening))
+    def verify(self, salt: bytes, opening: bytes) -> bool:
+        return self.value == digest(salt + opening)
 
     def to_hex(self) -> (str, str):
         return self.salt.hex(), self.value.hex()

--- a/privateSBOMExchange/src/petra/lib/crypto.py
+++ b/privateSBOMExchange/src/petra/lib/crypto.py
@@ -1,5 +1,30 @@
-import sys
+import secrets
+import hashlib
 
+DEFAULT_HASH_SIZE_BYTES=32 # 256 bit
+
+def hash(to_hash:bytes) -> bytes:
+        return hashlib.sha256(to_hash).digest()
+
+def get_salt() -> bytes:
+    rand = secrets.token_bytes(DEFAULT_HASH_SIZE_BYTES)
+
+    # we hash it as an extra measure to "hide" the random nonce
+    return hash(rand)
+
+class Commitment:
+    """ Implements a simple cryptographic commitment."""
+    def __init__(self, to_commit: bytes) -> None:
+        self.salt = get_salt()
+        self.value = hash(self.salt + to_commit)
+
+    def serialize(self, data: bytes) -> bytes:
+        return self.salt + data
+
+    def verify(self, opening: bytes) -> bool:
+        return self.value == hash(self.serialize(opening))
+
+'''
 try:
     from cpabe import cpabe_decrypt, cpabe_encrypt, cpabe_keygen, cpabe_setup, cpabe_delegate
 except:
@@ -31,6 +56,4 @@ def encrypt_SBOM(flatten_SBOM_data, pub_key, policy):
         ct = cpabe_encrypt(pub_key, policy, value.encode("utf-8"))
         result.append((key, ct))
     return result
-
-
-
+'''

--- a/privateSBOMExchange/src/petra/lib/models/tree_ops.py
+++ b/privateSBOMExchange/src/petra/lib/models/tree_ops.py
@@ -250,25 +250,29 @@ def verify_membership_proof(root_hash, target_hash, proofs):
     
     # Start with `target_hash` and use `proofs` to iteratively build a hash path.
     
-    contructed_path_hash = target_hash
+    constructed_path_hash = target_hash
     for proof in proofs:
         # Replace the "missing" entry in each proof with the current hash, 
         # join the path, then re-hash to produce the next level's hash.
-        proof[proof.index("missing")] = contructed_path_hash
-        contructed_path = b''.join(hash for hash in proof)
-        contructed_path_hash = digest(contructed_path)
+        proof[proof.index("missing")] = constructed_path_hash
+        constructed_path = b''.join(hash for hash in proof)
+        constructed_path_hash = digest(constructed_path)
 
-    return contructed_path_hash == root_hash
+    return constructed_path_hash == root_hash
 
 def verify_sameness(redacted: SbomNode, plaintext: SbomNode) -> bool:
     """
-    Recomputes the plaintext root hash and tree root hash for the given plaintext
-    SBOM tree. For a decrypted tree, this is done using decrypted node data and verifying
-    that it is identical to their pre-encryption state.
+    Recomputes the plaintext root hash and tree root hash for the given
+    plaintext SBOM tree. For a decrypted tree, this is done using decrypted
+    node data and verifying that it is identical to their pre-encryption
+    state.
     For an unredacted tree, the hashes are recomputed from leaf to root.
 
     Parameters:
-        node (SbomNode): The decrypted, redacted SBOM tree to be verified for sameness
+      redacted (SbomNode): The redacted SBOM tree
+        
+      plaintext (SbomNode): The unredacted or decrypted SBOM tree to be
+        verified for sameness
     """
 
     plaintext_sameness_vals = plaintext.get_sameness_verification_values()

--- a/privateSBOMExchange/src/petra/lib/models/tree_ops.py
+++ b/privateSBOMExchange/src/petra/lib/models/tree_ops.py
@@ -271,8 +271,6 @@ def verify_sameness(node: Node):
         print("Field node")
         #If no data was encrypted, the node is expected to be unchanged, but verify
         if node.decrypted_data:
-            print("Want: %s" % f"{node.field_name}{node.field_value}")
-            print("Got: %s" % node.decrypted_data)
             assert node.plaintext_commit.verify(node.decrypted_data.encode("utf-8"))
         else:
             assert node.plaintext_commit.verify((f"{node.field_name}{node.field_value}").encode("utf-8"))

--- a/privateSBOMExchange/src/petra/lib/models/tree_ops.py
+++ b/privateSBOMExchange/src/petra/lib/models/tree_ops.py
@@ -240,8 +240,6 @@ def verify_membership_proof(root_hash, target_hash, proofs):
     """
     Verify the membership proof for a target hash within an SBOM tree.
     """
-    def hash(to_hash):
-        return hashlib.sha256(to_hash).digest()
 
     if target_hash == root_hash:
         return True

--- a/privateSBOMExchange/src/petra/lib/util/config.py
+++ b/privateSBOMExchange/src/petra/lib/util/config.py
@@ -31,8 +31,6 @@ class Config:
         # store the CP-ABE info, if any
         cpabe_dict = self.config_dict.get("cp-abe")
 
-        print(self.config_dict)
-
         if cpabe_dict != None:
             # get the CP-ABE keys and policy, if any
 

--- a/privateSBOMExchange/src/petra/lib/util/config.py
+++ b/privateSBOMExchange/src/petra/lib/util/config.py
@@ -31,6 +31,8 @@ class Config:
         # store the CP-ABE info, if any
         cpabe_dict = self.config_dict.get("cp-abe")
 
+        print(self.config_dict)
+
         if cpabe_dict != None:
             # get the CP-ABE keys and policy, if any
 

--- a/privateSBOMExchange/tests/test_cpabe.py
+++ b/privateSBOMExchange/tests/test_cpabe.py
@@ -3,12 +3,11 @@ from lib4sbom.parser import SBOMParser
 import json
 import argparse
 
-from petra.lib.models.tree_ops import build_sbom_tree, sameness_verify
+from petra.lib.models.tree_ops import build_sbom_tree, verify_sameness
 from petra.lib.models import MerkleVisitor, EncryptVisitor, DecryptVisitor
 from petra.lib.util.config import Config
 
 import cpabe
-
 
 argparser = argparse.ArgumentParser()
 # TODO: add args for the config
@@ -44,6 +43,8 @@ print("done encrypting")
 merkle_visitor = MerkleVisitor()
 merkle_root_hash = sbom_tree.accept(merkle_visitor)
 
+print("done hashing tree")
+
 print("saving redacted tree to disk")
 
 with open(args.redacted_file, "w+") as f:
@@ -62,4 +63,4 @@ with open(args.decrypted_file, "w+") as f:
 
 # verify decrypted tree is consistent 
 # with original sbom tree
-sameness_verify(redacted_tree)
+verify_sameness(redacted_tree)

--- a/privateSBOMExchange/tests/test_cpabe.py
+++ b/privateSBOMExchange/tests/test_cpabe.py
@@ -12,6 +12,7 @@ import cpabe
 argparser = argparse.ArgumentParser()
 # TODO: add args for the config
 # TODO: handle defaults etc
+argparser.add_argument("-o", "--original-file", type=str, required=True, help="the file to which to write the original SBOM tree")
 argparser.add_argument("-r", "--redacted-file", type=str, required=True, help="the file to which to write the redacted SBOM tree")
 argparser.add_argument("-d", "--decrypted-file", type=str, required=True, help="the file to which to write the decrypted SBOM tree")
 args = argparser.parse_args()
@@ -34,6 +35,15 @@ sbom_tree = build_sbom_tree(sbom, conf.get_cpabe_policy('name-policy'))
 
 print("done constructing tree")
 
+# hash tree nodes
+merkle_visitor = MerkleVisitor()
+merkle_root_hash = sbom_tree.accept(merkle_visitor)
+
+with open(args.original_file, "w+") as f:
+        f.write(json.dumps(sbom_tree.to_dict(), indent=4)+'\n')
+
+print("pre-redaction plaintext hash: %s" % sbom_tree.plaintext_hash.hex())
+
 # encrypt node data
 encrypt_visitor = EncryptVisitor(pk)
 sbom_tree.accept(encrypt_visitor)
@@ -45,6 +55,8 @@ merkle_root_hash = sbom_tree.accept(merkle_visitor)
 
 print("done hashing tree")
 
+print("redacted plaintext hash: %s" % sbom_tree.plaintext_hash.hex())
+
 print("saving redacted tree to disk")
 
 with open(args.redacted_file, "w+") as f:
@@ -52,15 +64,19 @@ with open(args.redacted_file, "w+") as f:
 
 # decrypt node data
 decrypt_visitor = DecryptVisitor(sk)
-redacted_tree = copy.deepcopy(sbom_tree)
-redacted_tree.accept(decrypt_visitor)
+decrypted_tree = copy.deepcopy(sbom_tree)
+decrypted_tree.accept(decrypt_visitor)
 print("done decrypting")
+
+print("decrypted plaintext hash: %s" % decrypted_tree.plaintext_hash.hex())
 
 print("saving decrypted tree to disk")
 
 with open(args.decrypted_file, "w+") as f:
-        f.write(json.dumps(redacted_tree.to_dict(), indent=4)+'\n')
+        f.write(json.dumps(decrypted_tree.to_dict(), indent=4)+'\n')
 
 # verify decrypted tree is consistent 
 # with original sbom tree
-verify_sameness(redacted_tree)
+passed = verify_sameness(sbom_tree, decrypted_tree)
+
+print("full tree sameness verification passed? %s" % str(passed))

--- a/privateSBOMExchange/tests/test_crypto.py
+++ b/privateSBOMExchange/tests/test_crypto.py
@@ -3,11 +3,18 @@ from petra.lib.crypto import Commitment
 print("Creating commitment for byte string 0xdecafbad")
 
 commit = Commitment(b'decafbad')
+hexc = commit.to_hex()
 
-print("Got commitment: %s" % commit.value.hex())
+print("Got commitment: (%s, %s)" % (hexc[0], hexc[1]))
 
 print("Verification passed? %s" % str(commit.verify(b'decafbad')))
 
 print("Testing verification of bad commitment opening 0xdeadbeef")
 
 print("Verification passed? %s" % str(commit.verify(b'deadbeef')))
+
+print("Testing commitment reconstruction from hex tuple")
+
+recon_commit = Commitment.from_hex(hexc)
+
+print("Verification passed? %s" % str(recon_commit.verify(b'decafbad')))

--- a/privateSBOMExchange/tests/test_crypto.py
+++ b/privateSBOMExchange/tests/test_crypto.py
@@ -1,0 +1,13 @@
+from petra.lib.crypto import Commitment
+
+print("Creating commitment for byte string 0xdecafbad")
+
+commit = Commitment(b'decafbad')
+
+print("Got commitment: %s" % commit.value.hex())
+
+print("Verification passed? %s" % str(commit.verify(b'decafbad')))
+
+print("Testing verification of bad commitment opening 0xdeadbeef")
+
+print("Verification passed? %s" % str(commit.verify(b'deadbeef')))

--- a/privateSBOMExchange/tests/test_crypto.py
+++ b/privateSBOMExchange/tests/test_crypto.py
@@ -7,14 +7,14 @@ hexc = commit.to_hex()
 
 print("Got commitment: (%s, %s)" % (hexc[0], hexc[1]))
 
-print("Verification passed? %s" % str(commit.verify(b'decafbad')))
+print("Verification passed? %s" % str(commit.verify(commit.salt, b'decafbad')))
 
 print("Testing verification of bad commitment opening 0xdeadbeef")
 
-print("Verification passed? %s" % str(commit.verify(b'deadbeef')))
+print("Verification passed? %s" % str(commit.verify(commit.salt, b'deadbeef')))
 
 print("Testing commitment reconstruction from hex tuple")
 
 recon_commit = Commitment.from_hex(hexc)
 
-print("Verification passed? %s" % str(recon_commit.verify(b'decafbad')))
+print("Verification passed? %s" % str(recon_commit.verify(recon_commit.salt, b'decafbad')))


### PR DESCRIPTION
This PR replaces the simple hash-based content sameness verification with a basic commitment-based scheme.