### PR TITLE
Adopt unittest

### DIFF
--- a/privateSBOMExchange/README.md
+++ b/privateSBOMExchange/README.md
@@ -135,7 +135,7 @@ After the setup, you should be able to run the Petra CLI by running the test fil
 For example:
 
 ```bash
-python tests/test_models.py
+python -m unittest tests/test_models.py
 ```
 
 Should showcase an encryption and selective decription of target sbom --- make

--- a/privateSBOMExchange/src/petra/models/parallel_encrypt.py
+++ b/privateSBOMExchange/src/petra/models/parallel_encrypt.py
@@ -1,17 +1,17 @@
-from multiprocessing import Pool
-from cpabe import cpabe_encrypt, cpabe_decrypt, ac17_cpabe_encrypt, ac17_cpabe_decrypt, cpabe_decrypt_many, cpabe_encrypt_many
-import configparser
-import os
-
+from cpabe import cpabe_encrypt, cpabe_decrypt, ac17_cpabe_encrypt, ac17_cpabe_decrypt
+from concurrent.futures import ThreadPoolExecutor
+from petra.crypto import encrypt_data_AES, decrypt_data_AES
 from petra.models import FieldNode, SbomNode, ComplexNode, NODE_REDACTED, NODE_PUBLIC
 
-class ParallelEncryptVisitor:
 
-    """Visitor that does a 'collect then encrypt parallely' process to
-    increase performance"""
+class ParallelEncryptVisitor:
+    """Visitor that collects node data on traversal, then encrypts in finalize."""
+
     def __init__(self, pk, decryptor="cpabe"):
         self.pk = pk
-        self.workqueue = [] 
+        self.workqueue = []
+        self.__aes_key_dict = {}
+        self.root_sbom_node = None
         if decryptor == "cpabe":
             self.target_func = cpabe_encrypt
         elif decryptor == "ac17":
@@ -19,80 +19,56 @@ class ParallelEncryptVisitor:
         else:
             print("I don't support this cpabe scheme, use either cpabe or ac17")
 
-    def central_visit(self, node):
-        if node.type == NODE_COMPLEX:
-            self._visit_complex_node(node)
-        elif node.type == NODE_SBOM:
-            self._visit_sbom_node(node)
-        elif node.type == NODE_FIELD:
-            self._visit_field_node(node)
-
     def finalize(self):
-        if len(self.workqueue) < 1:
-            return
-        policy = [x[2] for x in self.workqueue]
-        plaintext = [x[3] for x in self.workqueue]
-        pk = self.workqueue[0][1]
-        nodes = [x[0] for x in self.workqueue] 
-        #with Pool(processes=os.cpu_count()) as pool:
-        #    result = pool.starmap(self.target_func, targets)
-        #result = cpabe_encrypt_many(pk, policy, plaintext)
-        if self.target_func is cpabe_encrypt:
-            result = cpabe_encrypt_many(pk, policy, plaintext)
-        else:
-            # ac17: no encrypt_many, call per-node
-            result = [
-                self.target_func(pk, pol, pt)
-                for pol, pt in zip(policy, plaintext)
-            ]
-        for node, encrypted_buffer in zip(nodes, result):
-            node.encrypted_data = encrypted_buffer
+        # AES-encrypt each collected node's data under its per-policy AES key
+        def encrypt_node(node_data_pair):
+            node, data = node_data_pair
+            return node, encrypt_data_AES(data, self.__aes_key_dict[node.policy])
+
+        def wrap_key(policy_key_pair):
+            policy, key = policy_key_pair
+            return policy, self.target_func(self.pk, policy, key)
+
+        with ThreadPoolExecutor() as executor:
+            for node, encrypted_data in executor.map(encrypt_node, self.workqueue):
+                node.encrypted_data = encrypted_data
+
+            if self.root_sbom_node:
+                for policy, wrapped_key in executor.map(
+                    wrap_key, self.__aes_key_dict.items()
+                ):
+                    self.root_sbom_node.encrypted_data[policy] = wrapped_key
+                    self.root_sbom_node.policy[policy] = NODE_REDACTED
 
     def visit_field_node(self, node: FieldNode):
-        """Visit a FieldNode and encrypt its data using cpabe
-        before encryption, the visitor fetch policy associated with node.field_name
-        
-        Parameters
-        ----------
-        node : FieldNode
-            The field node whose data will be hashed.
-        """
         data_to_encrypt = node.get_encryption_value()
-
         if node.policy != "" and data_to_encrypt:
-            #print("data_to_encrypt: %s (total size= %s)" % (data_to_encrypt[32:].decode("utf-8"), str(len(data_to_encrypt))))
-            
-            # we append to the workqueue instead of actually encrypting
-            self.workqueue.append((node, self.pk, node.policy, data_to_encrypt))
+            self.workqueue.append((node, data_to_encrypt))
+            node.field_name = NODE_REDACTED
+            node.field_value = NODE_REDACTED
 
-    def visit_complex_node(self, node:ComplexNode):
-        """Encrypt the data for a ComplexNode and assign policies to its children."""
-        data_to_encrypt =  node.get_encryption_value()
-
+    def visit_complex_node(self, node: ComplexNode):
+        data_to_encrypt = node.get_encryption_value()
         if node.policy != "" and data_to_encrypt:
-            # we append to the workqueue instead of actually encrypting
-            self.workqueue.append((node, self.pk, node.policy, data_to_encrypt))
-
-            #print(f"policy found for ComplexNode {node.complex_type} , {node.policy}")
-
-        for child in node.children:
-            child.accept(self)  # Visit each child
-
-    def visit_sbom_node(self, node: SbomNode):
-        """Visit an SbomNode and accept its children without encrypting."""
-        print(f"Visiting SbomNode '{node.purl}', accepting children.")
-        
-        # Accept all child nodes without encryption
+            self.workqueue.append((node, data_to_encrypt))
+            node.complex_type = NODE_REDACTED
         for child in node.children:
             child.accept(self)
 
+    def visit_sbom_node(self, node: SbomNode):
+        self.__aes_key_dict = node.policy
+        self.root_sbom_node = node
+        for child in node.children:
+            child.accept(self)
+
+
 class ParallelDecryptVisitor:
-    """A visitor that traverses nodes in the and decrypts encrypted data
-    in each node using the provided secret key."""
+    """Visitor that collects encrypted nodes on traversal, then decrypts in finalize."""
+
     def __init__(self, secret_key, decryptor="cpabe"):
-        # TODO: Get user's secret key from database
         self.secret_key = secret_key
         self.workqueue = []
+        self.__decrypted_aes_keys = {}
         if decryptor == "cpabe":
             self.target_func = cpabe_decrypt
         elif decryptor == "ac17":
@@ -101,52 +77,35 @@ class ParallelDecryptVisitor:
             print("I don't support this cpabe scheme, use either cpabe or ac17")
 
     def finalize(self):
-        if len(self.workqueue) < 1:
-            return
-        #targets = [(x[1], x[2]) for x in self.workqueue]
-        sk = self.workqueue[0][1]
-        targets = [ x[2] for x in self.workqueue]
-        nodes = [x[0] for x in self.workqueue] 
-        #with Pool(processes=os.cpu_count()) as pool:
-        #    result = pool.starmap(self.target_func, targets)
+        def decrypt_node(node):
+            return node, decrypt_data_AES(
+                node.encrypted_data, self.__decrypted_aes_keys[node.policy]
+            )
 
-        if self.target_func is cpabe_decrypt:
-            result = cpabe_decrypt_many(sk, targets)
-        else:
-            # ac17 path: decrypt each ciphertext individually
-            result = [self.target_func(sk, ct) for ct in targets]
-        #result = cpabe_decrypt_many(sk, targets)
+        with ThreadPoolExecutor() as executor:
+            for node, decrypted_data in executor.map(decrypt_node, self.workqueue):
+                node.decrypted_data = decrypted_data
 
-        for node, decrypted_buffer in zip(nodes, result):
-            # decrypted_data is stored as bytes now, cpabe_decrypt returns a list
-            node.decrypted_data = bytes(decrypted_buffer)
+        del self.__decrypted_aes_keys
 
     def visit_field_node(self, node: FieldNode):
-        """Visit a FieldNode and decrypt its encrypted data using the secret key
-        Parameters
-        ----------
-        node : FieldNode
-            The field node whose ciphertext will be decrypted.
-        """
         if node.encrypted_data != NODE_PUBLIC:
-            self.workqueue.append((node, self.secret_key, node.encrypted_data))
-        else:
-            pass
-            #print(f"No encrypted data found for FieldNode '{node.field_name}'.")
+            self.workqueue.append(node)
 
-    def visit_complex_node(self, node:ComplexNode):  
-        # Visit and decrypt all child nodes.
+    def visit_complex_node(self, node: ComplexNode):
         if node.encrypted_data != NODE_PUBLIC:
-            self.workqueue.append((node, self.secret_key, node.encrypted_data))
-
-        for child in node.children:
-            child.accept(self)  
-
-    def visit_sbom_node(self, node: SbomNode): 
-        # Visit and decrypt all child nodes.  
+            self.workqueue.append(node)
         for child in node.children:
             child.accept(self)
 
-        del self.secret_key
-
-
+    def visit_sbom_node(self, node: SbomNode):
+        # CP-ABE-unwrap the per-policy AES keys so the root plaintext_hash can be
+        # recomputed
+        if len(node.policy) > 0:
+            for policy, encrypted_aes_key in node.encrypted_data.items():
+                node.decrypted_policy[policy] = bytes(
+                    self.target_func(self.secret_key, encrypted_aes_key)
+                )
+        self.__decrypted_aes_keys = node.decrypted_policy
+        for child in node.children:
+            child.accept(self)

--- a/privateSBOMExchange/src/petra/models/parallel_minimal.py
+++ b/privateSBOMExchange/src/petra/models/parallel_minimal.py
@@ -1,0 +1,109 @@
+from cpabe import (
+    cpabe_encrypt,
+    cpabe_decrypt,
+    ac17_cpabe_encrypt,
+    ac17_cpabe_decrypt,
+    cpabe_decrypt_many,
+    cpabe_encrypt_many,
+)
+
+from petra.models import FieldNode, SbomNode, ComplexNode, NODE_REDACTED, NODE_PUBLIC
+
+
+class ParallelEncryptVisitor:
+    def __init__(self, pk, decryptor="cpabe"):
+        self.pk = pk
+        self.workqueue = []
+        self.root_sbom_node = None
+        if decryptor == "cpabe":
+            self.target_func = cpabe_encrypt
+        elif decryptor == "ac17":
+            self.target_func = ac17_cpabe_encrypt
+        else:
+            print("I don't support this cpabe scheme, use either cpabe or ac17")
+
+    def finalize(self):
+        if self.workqueue:
+            policy = [x[2] for x in self.workqueue]
+            plaintext = [x[3] for x in self.workqueue]
+            pk = self.workqueue[0][1]
+            nodes = [x[0] for x in self.workqueue]
+            if self.target_func is cpabe_encrypt:
+                result = cpabe_encrypt_many(pk, policy, plaintext)
+            else:
+                result = [
+                    self.target_func(pk, pol, pt) for pol, pt in zip(policy, plaintext)
+                ]
+            for node, encrypted_buffer in zip(nodes, result):
+                node.encrypted_data = encrypted_buffer
+
+        if self.root_sbom_node:
+            for policy, key in list(self.root_sbom_node.policy.items()):
+                self.root_sbom_node.encrypted_data[policy] = self.target_func(
+                    self.pk, policy, key
+                )
+                self.root_sbom_node.policy[policy] = NODE_REDACTED
+
+    def visit_field_node(self, node: FieldNode):
+        data_to_encrypt = node.get_encryption_value()
+        if node.policy != "" and data_to_encrypt:
+            self.workqueue.append((node, self.pk, node.policy, data_to_encrypt))
+
+    def visit_complex_node(self, node: ComplexNode):
+        data_to_encrypt = node.get_encryption_value()
+        if node.policy != "" and data_to_encrypt:
+            self.workqueue.append((node, self.pk, node.policy, data_to_encrypt))
+        for child in node.children:
+            child.accept(self)
+
+    def visit_sbom_node(self, node: SbomNode):
+        self.root_sbom_node = node
+        for child in node.children:
+            child.accept(self)
+
+
+class ParallelDecryptVisitor:
+    def __init__(self, secret_key, decryptor="cpabe"):
+        self.secret_key = secret_key
+        self.workqueue = []
+        if decryptor == "cpabe":
+            self.target_func = cpabe_decrypt
+        elif decryptor == "ac17":
+            self.target_func = ac17_cpabe_decrypt
+        else:
+            print("I don't support this cpabe scheme, use either cpabe or ac17")
+
+    def finalize(self):
+        if len(self.workqueue) < 1:
+            return
+        sk = self.workqueue[0][1]
+        targets = [x[2] for x in self.workqueue]
+        nodes = [x[0] for x in self.workqueue]
+        if self.target_func is cpabe_decrypt:
+            result = cpabe_decrypt_many(sk, targets)
+        else:
+            result = [self.target_func(sk, ct) for ct in targets]
+        for node, decrypted_buffer in zip(nodes, result):
+            node.decrypted_data = bytes(decrypted_buffer)
+
+        del self.secret_key
+
+    def visit_field_node(self, node: FieldNode):
+        if node.encrypted_data != NODE_PUBLIC:
+            self.workqueue.append((node, self.secret_key, node.encrypted_data))
+
+    def visit_complex_node(self, node: ComplexNode):
+        if node.encrypted_data != NODE_PUBLIC:
+            self.workqueue.append((node, self.secret_key, node.encrypted_data))
+        for child in node.children:
+            child.accept(self)
+
+    def visit_sbom_node(self, node: SbomNode):
+        if len(node.policy) > 0:
+            for policy, encrypted_aes_key in node.encrypted_data.items():
+                node.decrypted_policy[policy] = bytes(
+                    self.target_func(self.secret_key, encrypted_aes_key)
+                )
+
+        for child in node.children:
+            child.accept(self)

--- a/privateSBOMExchange/tests/test_AES.py
+++ b/privateSBOMExchange/tests/test_AES.py
@@ -1,20 +1,18 @@
-from Crypto.Cipher import AES
-from Crypto.Random import get_random_bytes
-import base64
+import unittest
 
-from petra.crypto import generate_AES_key, encrypt_data_AES,decrypt_data_AES
 
-# Example usage:
-if __name__ == "__main__":
-    # Generate a new AES key (32 bytes for AES-256)
-    key = generate_AES_key()
-    print(f"Generated Key: {key.hex()}")  # Printing key in hex format for better readability
+from petra.crypto import generate_AES_key, encrypt_data_AES, decrypt_data_AES
 
-    # Encrypt a message
-    plaintext = "This is a secret message."
-    encrypted_data = encrypt_data_AES(plaintext.encode(), key)
-    print(f"Encrypted Data (Base64): {encrypted_data}")
 
-    # Decrypt the message
-    decrypted_message = decrypt_data_AES(encrypted_data, key)
-    print(f"Decrypted Message: {decrypted_message}")
+class TestAES(unittest.TestCase):
+    def test_example_usage(self):
+        # Generate a new AES key (32 bytes for AES-256)
+        key = generate_AES_key()
+
+        # Encrypt a message
+        plaintext = "This is a secret message."
+        encrypted_data = encrypt_data_AES(plaintext.encode(), key)
+
+        # Decrypt the message
+        decrypted_message = decrypt_data_AES(encrypted_data, key)
+        self.assertEqual(plaintext, decrypted_message.decode())

--- a/privateSBOMExchange/tests/test_ac17_cpabe.py
+++ b/privateSBOMExchange/tests/test_ac17_cpabe.py
@@ -1,58 +1,60 @@
 import copy
+import unittest
 from lib4sbom.parser import SBOMParser
 from petra.util.config import Config
 
-from petra.models.tree_ops import verify_sameness ,build_sbom_tree
-from petra.models.parallel_encrypt import ParallelEncryptVisitor, ParallelDecryptVisitor
-from petra.models import MerkleVisitor, EncryptVisitor, DecryptVisitor
+from petra.models.tree_ops import verify_sameness, build_sbom_tree
+from petra.models import MerkleVisitor
+from petra.models import parallel_encrypt, parallel_minimal
 import cpabe
 
-bom_conf = Config("config/bom-only.conf")
-policy_conf = Config("config/ip-policy.conf")
 
-# get all config files
-sbom_file = bom_conf.get_sbom_files()[0]
-ip_policy_file = policy_conf.get_cpabe_policy("ip-policy")
+class TestAC17_CPABE(unittest.TestCase):
+    def test_redaction_roundtrip(self):
+        for encryptor, decryptor in [
+            (
+                parallel_encrypt.ParallelEncryptVisitor,
+                parallel_encrypt.ParallelDecryptVisitor,
+            ),
+            (
+                parallel_minimal.ParallelEncryptVisitor,
+                parallel_minimal.ParallelDecryptVisitor,
+            ),
+        ]:
+            with self.subTest(encryptor=encryptor, decryptor=decryptor):
+                bom_conf = Config("config/bom-only.conf")
+                policy_conf = Config("config/ip-policy.conf")
 
-# get cpabe groups
-ip_group = policy_conf.get_cpabe_group('ip-group')
-time_attributes="epoch:1767744000"
-ip_group.append(time_attributes)
+                sbom_file = bom_conf.get_sbom_files()[0]
+                ip_policy_file = policy_conf.get_cpabe_policy("ip-policy")
 
-pk, mk = cpabe.ac17_cpabe_setup()
-sk = cpabe.ac17_cpabe_keygen(mk, ip_group)
+                ip_group = policy_conf.get_cpabe_group("ip-group")
+                ip_group.append("epoch:1767744000")
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(sbom_file) 
+                pk, mk = cpabe.ac17_cpabe_setup()
+                sk = cpabe.ac17_cpabe_keygen(mk, ip_group)
 
-# build sbom tree
-sbom=SBOM_parser.sbom
-time_tree="(\"epoch:1767744000\")"
+                SBOM_parser = SBOMParser()
+                SBOM_parser.parse_file(sbom_file)
 
-sbom_tree = build_sbom_tree(sbom,time_tree,ip_policy_file)
+                sbom = SBOM_parser.sbom
+                time_tree = '("epoch:1767744000")'
+                sbom_tree = build_sbom_tree(sbom, time_tree, ip_policy_file)
 
-# hash tree nodes
-merkle_visitor = MerkleVisitor()
-merkle_root_hash = sbom_tree.accept(merkle_visitor)
+                # encrypt node data (before hashing so redaction's captured)
+                # TODO: Enforce this ordering so it can't be messed up
+                encrypt_visitor = encryptor(pk, "ac17")
+                sbom_tree.accept(encrypt_visitor)
+                encrypt_visitor.finalize()
 
+                # hash tree nodes
+                sbom_tree.accept(MerkleVisitor())
 
-# encrypt node data
-encrypt_visitor = ParallelEncryptVisitor(pk, "ac17")
-sbom_tree.accept(encrypt_visitor)
-encrypt_visitor.finalize()
-print("done encrypting")
+                # decrypt a copy of the redacted tree
+                redacted_tree = copy.deepcopy(sbom_tree)
+                decrypt_visitor = decryptor(sk, "ac17")
+                redacted_tree.accept(decrypt_visitor)
+                decrypt_visitor.finalize()
 
-# decrypt node data
-decrypt_visitor = ParallelDecryptVisitor(sk, "ac17")
-redacted_tree = copy.deepcopy(sbom_tree)
-redacted_tree.accept(decrypt_visitor)
-decrypt_visitor.finalize()
-print("done decrypting")
-
-# verify decrypted tree is consistent 
-# with original sbom tree
-verify_sameness(sbom_tree,redacted_tree)
-
-
-
+                # the decrypted tree must be provably the same as the redacted tree
+                self.assertTrue(verify_sameness(sbom_tree, redacted_tree))

--- a/privateSBOMExchange/tests/test_commitment.py
+++ b/privateSBOMExchange/tests/test_commitment.py
@@ -1,20 +1,18 @@
+import unittest
+
 from petra.crypto import Commitment
 
-print("Creating commitment for byte string 0xdecafbad")
 
-commit = Commitment(b'decafbad')
-hexc = commit.to_hex()
+class TestComitment(unittest.TestCase):
+    def test_end_to_end_commitment(self):
 
-print("Got commitment: (%s, %s)" % (hexc[0], hexc[1]))
+        commit = Commitment(b"decafbad")
+        hexc = commit.to_hex()
 
-print("Verification passed? %s" % str(commit.verify(commit.salt, b'decafbad')))
+        self.assertTrue(commit.verify(commit.salt, b"decafbad"))
 
-print("Testing verification of bad commitment opening 0xdeadbeef")
+        self.assertFalse(commit.verify(commit.salt, b"deadbeef"))
 
-print("Verification passed? %s" % str(commit.verify(commit.salt, b'deadbeef')))
+        recon_commit = Commitment.from_hex(hexc)
 
-print("Testing commitment reconstruction from hex tuple")
-
-recon_commit = Commitment.from_hex(hexc)
-
-print("Verification passed? %s" % str(recon_commit.verify(recon_commit.salt, b'decafbad')))
+        self.assertTrue(recon_commit.verify(recon_commit.salt, b"decafbad"))

--- a/privateSBOMExchange/tests/test_cpabe.py
+++ b/privateSBOMExchange/tests/test_cpabe.py
@@ -1,98 +1,70 @@
 import copy
-from lib4sbom.parser import SBOMParser
 import json
-import argparse
+import tempfile
+import unittest
+from lib4sbom.parser import SBOMParser
 
 from petra.models.tree_ops import build_sbom_tree, verify_sameness
 from petra.models import MerkleVisitor, EncryptVisitor, DecryptVisitor
-from petra.models.parallel_encrypt import ParallelEncryptVisitor, ParallelDecryptVisitor
+from petra.models import parallel_encrypt, parallel_minimal
 from petra.util.config import Config
-
 import cpabe
 
-argparser = argparse.ArgumentParser()
-# TODO: add args for the config
-# TODO: handle defaults etc
-argparser.add_argument("-o", "--original-file", type=str, required=True, help="the file to which to write the original SBOM tree")
-argparser.add_argument("-r", "--redacted-file", type=str, required=True, help="the file to which to write the redacted SBOM tree")
-argparser.add_argument("-d", "--decrypted-file", type=str, required=True, help="the file to which to write the decrypted SBOM tree")
-argparser.add_argument("--no-parallel", action='store_true', help="flag indicating whether to parallelize SBOM tree encryption/decryption")
-args = argparser.parse_args()
 
-# read in the IP policy config
-conf = Config("./config/ip-policy.conf")
+class TestCPABE(unittest.TestCase):
+    def test_redaction_roundtrip(self):
+        for encryptor, decryptor in [
+            (EncryptVisitor, DecryptVisitor),
+            (
+                parallel_encrypt.ParallelEncryptVisitor,
+                parallel_encrypt.ParallelDecryptVisitor,
+            ),
+            (
+                parallel_minimal.ParallelEncryptVisitor,
+                parallel_minimal.ParallelDecryptVisitor,
+            ),
+        ]:
+            with self.subTest(encryptor=encryptor, decryptor=decryptor):
+                conf = Config("config/ip-policy.conf")
+                sbom_file = conf.get_sbom_files()[0]
 
-sbom_file = conf.get_sbom_files()[0]
+                pk, mk = cpabe.cpabe_setup()
+                user_attributes = conf.get_cpabe_group("ip-group")
+                user_attributes.append("epoch:1767744000")
+                sk = cpabe.cpabe_keygen(pk, mk, user_attributes)
 
-pk, mk = cpabe.cpabe_setup()
-time_attributes="epoch:1767744000"
-user_attributes=conf.get_cpabe_group('ip-group')
-user_attributes.append(time_attributes)
-sk = cpabe.cpabe_keygen(pk, mk, user_attributes)
+                SBOM_parser = SBOMParser()
+                SBOM_parser.parse_file(sbom_file)
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(sbom_file) 
+                sbom = SBOM_parser.sbom
+                time_tree = '("epoch:1767744000")'
+                sbom_tree = build_sbom_tree(
+                    sbom, time_tree, conf.get_cpabe_policy("ip-policy")
+                )
+                with tempfile.TemporaryFile(mode="w+") as f:
+                    json.dump(sbom_tree.to_dict(), f)
 
-# build sbom tree
-sbom=SBOM_parser.sbom
-time_tree="(\"epoch:1767744000\")"
-sbom_tree = build_sbom_tree(sbom,time_tree ,conf.get_cpabe_policy('ip-policy'))
+                # encrypt node data (before hashing the tree)
+                encrypt_visitor = encryptor(pk)
+                sbom_tree.accept(encrypt_visitor)
+                if hasattr(encrypt_visitor, "finalize"):
+                    encrypt_visitor.finalize()
 
-print("done constructing tree")
+                # hash tree nodes
+                sbom_tree.accept(MerkleVisitor())
 
-with open(args.original_file, "w+") as f:
-        f.write(json.dumps(sbom_tree.to_dict(), indent=4)+'\n')
+                with tempfile.TemporaryFile(mode="w+") as f:
+                    json.dump(sbom_tree.to_dict(), f)
 
-print("pre-redaction plaintext hash: %s" % sbom_tree.plaintext_hash.hex())
+                # decrypt a copy of the redacted tree
+                redacted_tree = copy.deepcopy(sbom_tree)
+                decrypt_visitor = decryptor(sk)
+                redacted_tree.accept(decrypt_visitor)
+                if hasattr(decrypt_visitor, "finalize"):
+                    decrypt_visitor.finalize()
 
-# encrypt node data
-if args.no_parallel:
-        encrypt_visitor = EncryptVisitor(pk)
-        sbom_tree.accept(encrypt_visitor)
-else:
-        # we default to the parallel encryption
-        encrypt_visitor = ParallelEncryptVisitor(pk)
-        sbom_tree.accept(encrypt_visitor)
-        encrypt_visitor.finalize()
+                with tempfile.TemporaryFile(mode="w+") as f:
+                    json.dump(redacted_tree.to_dict(), f)
 
-print("done encrypting")
-
-# hash tree nodes
-merkle_visitor = MerkleVisitor()
-merkle_root_hash = sbom_tree.accept(merkle_visitor)
-
-print("done hashing tree")
-
-print("redacted plaintext hash: %s" % sbom_tree.plaintext_hash.hex())
-
-print("saving redacted tree to disk")
-
-with open(args.redacted_file, "w+") as f:
-        f.write(json.dumps(sbom_tree.to_dict(), indent=4)+'\n')
-
-# decrypt node data
-decrypted_tree = copy.deepcopy(sbom_tree)
-if args.no_parallel:
-        decrypt_visitor = DecryptVisitor(sk)
-        decrypted_tree.accept(decrypt_visitor)
-else:
-        # we default to the parallel decryption
-        decrypt_visitor = ParallelDecryptVisitor(sk)
-        decrypted_tree.accept(decrypt_visitor)
-        decrypt_visitor.finalize()
-
-print("done decrypting")
-
-print("decrypted plaintext hash: %s" % decrypted_tree.plaintext_hash.hex())
-
-print("saving decrypted tree to disk")
-
-with open(args.decrypted_file, "w+") as f:
-        f.write(json.dumps(decrypted_tree.to_dict(), indent=4)+'\n')
-
-# verify decrypted tree is consistent 
-# with original sbom tree
-passed = verify_sameness(sbom_tree, decrypted_tree)
-
-print("full tree sameness verification passed? %s" % str(passed))
+                # the decrypted tree must be provably the same as the redacted tree
+                self.assertTrue(verify_sameness(sbom_tree, redacted_tree))

--- a/privateSBOMExchange/tests/test_cpabe_AES.py
+++ b/privateSBOMExchange/tests/test_cpabe_AES.py
@@ -1,7 +1,8 @@
 import copy
+import tempfile
+import unittest
 from lib4sbom.parser import SBOMParser
 import json
-import argparse
 
 from petra.models.tree_ops import build_sbom_tree, verify_sameness
 from petra.models import MerkleVisitor, EncryptVisitor, DecryptVisitor
@@ -9,72 +10,53 @@ from petra.util.config import Config
 
 import cpabe
 
-argparser = argparse.ArgumentParser()
-# TODO: add args for the config
-# TODO: handle defaults etc
-argparser.add_argument("-u", "--unredacted-file", type=str, help="the file to which to write the unredacted SBOM tree")
-argparser.add_argument("-r", "--redacted-file", type=str, help="the file to which to write the redacted SBOM tree")
-argparser.add_argument("-d", "--decrypted-file", type=str, help="the file to which to write the decrypted SBOM tree")
-args = argparser.parse_args()
 
-# read in the IP policy config
-#conf = Config("./config/test-AES.conf")
-conf = Config("./config/ip-policy.conf")
+class TestCP_ABE_AES(unittest.TestCase):
+    def test_serial_enc_dec_visitors(self):
+        # read in the IP policy config
+        conf = Config("./config/ip-policy.conf")
 
-sbom_file = conf.get_sbom_files()[0]
+        sbom_file = conf.get_sbom_files()[0]
 
-pk, mk = cpabe.cpabe_setup()
-time_attributes="epoch:1767744000"
-user_attributes=conf.get_cpabe_group('ip-group')
-user_attributes.append(time_attributes)
-sk = cpabe.cpabe_keygen(pk, mk, user_attributes)
+        pk, mk = cpabe.cpabe_setup()
+        time_attributes = "epoch:1767744000"
+        user_attributes = conf.get_cpabe_group("ip-group")
+        user_attributes.append(time_attributes)
+        sk = cpabe.cpabe_keygen(pk, mk, user_attributes)
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(sbom_file) 
+        # Parse SPDX data into a Document object
+        SBOM_parser = SBOMParser()
+        SBOM_parser.parse_file(sbom_file)
 
-# build sbom tree
-sbom=SBOM_parser.sbom
-time_tree="(\"epoch:1767744000\")"
+        # build sbom tree
+        sbom = SBOM_parser.sbom
+        time_tree = '("epoch:1767744000")'
 
-sbom_tree = build_sbom_tree(sbom, time_tree,conf.get_cpabe_policy('ip-policy'))
+        sbom_tree = build_sbom_tree(sbom, time_tree, conf.get_cpabe_policy("ip-policy"))
 
-print("done constructing tree")
+        with tempfile.TemporaryFile(mode="w+") as f:
+            f.write(json.dumps(sbom_tree.to_dict(), indent=4) + "\n")
 
-if args.unredacted_file:
-    with open(args.unredacted_file, "w+") as f:
-        f.write(json.dumps(sbom_tree.to_dict(), indent=4)+'\n')
+        # encrypt node data
+        encrypt_visitor = EncryptVisitor(pk)
+        sbom_tree.accept(encrypt_visitor)
 
-# encrypt node data
-encrypt_visitor = EncryptVisitor(pk)
-sbom_tree.accept(encrypt_visitor)
-print("done encrypting")
+        # hash tree nodes
+        merkle_visitor = MerkleVisitor()
+        sbom_tree.accept(merkle_visitor)
 
-# hash tree nodes
-merkle_visitor = MerkleVisitor()
-merkle_root_hash_original = sbom_tree.accept(merkle_visitor)
+        sbom_tree.sign(conf.get_tree_signing_key())
 
-print("done hashing tree")
+        # decrypt node data
+        decrypt_visitor = DecryptVisitor(sk)
+        decrypted_tree = copy.deepcopy(sbom_tree)
+        decrypted_tree.accept(decrypt_visitor)
 
-print("signing the tree")
-sbom_tree.sign(conf.get_tree_signing_key())
+        with tempfile.TemporaryFile(mode="w+") as f:
+            f.write(json.dumps(decrypted_tree.to_dict(), indent=4) + "\n")
 
-# decrypt node data
-decrypt_visitor = DecryptVisitor(sk)
-decrypted_tree = copy.deepcopy(sbom_tree)
-decrypted_tree.accept(decrypt_visitor)
-print("done decrypting")
+        self.assertTrue(decrypted_tree.verify_signature(conf.get_tree_public_key()))
 
-print("saving decrypted tree to disk")
+        passed = verify_sameness(sbom_tree, decrypted_tree)
 
-if args.decrypted_file:
-    with open(args.decrypted_file, "w+") as f:
-        f.write(json.dumps(decrypted_tree.to_dict(), indent=4)+'\n')
-
-print("decrypted tree signature verification passed? %s" % str(decrypted_tree.verify_signature(conf.get_tree_public_key())))
-
-# verify decrypted tree is consistent 
-# with original sbom tree
-passed = verify_sameness(sbom_tree, decrypted_tree)
-
-print("full tree sameness verification passed? %s" % str(passed))
+        self.assertTrue(passed)

--- a/privateSBOMExchange/tests/test_membership.py
+++ b/privateSBOMExchange/tests/test_membership.py
@@ -1,42 +1,46 @@
-"""This tests whether a target has is a member of a tree 
-"""
+"""This tests whether a target has is a member of a tree"""
+
 import configparser
+import unittest
 from lib4sbom.parser import SBOMParser
 from petra.util.config import Config
-from petra.models import  MerkleVisitor
-from petra.models.tree_ops import build_sbom_tree,GetTargetNodes, get_membership_proof, verify_membership_proof
-def is_member(root_hash, target_hash, proof):
-    return verify_membership_proof(root_hash, target_hash, proof)
-
-conf = Config("config/bom-only.conf")
-bom_file = conf.get_sbom_files()[0]
-
-config = configparser.ConfigParser()
-config.read('config/config.ini')
-policy_file =  config['POLICY']['empty_policy']
+from petra.models import MerkleVisitor
+from petra.models.tree_ops import (
+    build_sbom_tree,
+    GetTargetNodes,
+    get_membership_proof,
+    verify_membership_proof,
+)
 
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(bom_file)     
-sbom=SBOM_parser.sbom
-sbom_tree = build_sbom_tree(sbom,"",policy_file)
+class TestMembership(unittest.TestCase):
+    def test_merkle_membership(self):
+        conf = Config("config/bom-only.conf")
+        bom_file = conf.get_sbom_files()[0]
 
+        config = configparser.ConfigParser()
+        config.read("config/config.ini")
+        policy_file = config["POLICY"]["empty_policy"]
 
-# hash nodes in the tree
-merkle_visitor = MerkleVisitor()
-merkle_root_hash = sbom_tree.accept(merkle_visitor)
+        # Parse SPDX data into a Document object
+        SBOM_parser = SBOMParser()
+        SBOM_parser.parse_file(bom_file)
+        sbom = SBOM_parser.sbom
+        sbom_tree = build_sbom_tree(sbom, "", policy_file)
 
+        # hash nodes in the tree
+        merkle_visitor = MerkleVisitor()
+        merkle_root_hash = sbom_tree.accept(merkle_visitor)
 
-# Retrieve hashes of all nodes in the tree
-hash_hunter = GetTargetNodes()
-sbom_tree.accept(hash_hunter)
-target_hashes = hash_hunter.get_hashes()
+        # Retrieve hashes of all nodes in the tree
+        hash_hunter = GetTargetNodes()
+        sbom_tree.accept(hash_hunter)
+        target_hashes = hash_hunter.get_hashes()
 
-#Get and verify membership proof
-for hash in target_hashes:
-    proof = get_membership_proof(sbom_tree, hash)
-    assert is_member(merkle_root_hash, hash, proof) == True
+        # Get and verify membership proof
+        for hash in target_hashes:
+            proof = get_membership_proof(sbom_tree, hash)
+            self.assertTrue(verify_membership_proof(merkle_root_hash, hash, proof))
 
-# negative test
-assert get_membership_proof(sbom_tree, [b'lol']) == None
+        # negative test
+        self.assertIsNone(get_membership_proof(sbom_tree, [b"lol"]))

--- a/privateSBOMExchange/tests/test_models.py
+++ b/privateSBOMExchange/tests/test_models.py
@@ -1,44 +1,44 @@
 import configparser
+import unittest
 from lib4sbom.parser import SBOMParser
 
-from petra.models import *
+from petra.models import EncryptVisitor, MerkleVisitor, PrintVisitor
 from petra.models.tree_ops import build_sbom_tree
-from petra.util import config
 from petra.util.config import Config
 
 """This tests inserting a sbom as tree ,assuming Non of the dependencies has its own sbom 
 """
 
-# get the SBOM from the basic config
-conf = Config("config/bom-only.conf")
-bom_file = conf.get_sbom_files()[0]
 
-config = configparser.ConfigParser()
-config.read('config/config.ini')
-policy_file =  config['POLICY']['empty_policy']
+class TestModels(unittest.TestCase):
+    def test_sbom_with_child_load(self):
+        # get the SBOM from the basic config
+        conf = Config("config/bom-only.conf")
+        bom_file = conf.get_sbom_files()[0]
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(bom_file)   
-#SBOM_parser.parse_file("simple_sbom.json")
-# Build the tree and compute the root hash
-sbom=SBOM_parser.sbom
-sbom_tree = build_sbom_tree(sbom,"",policy_file)
+        config = configparser.ConfigParser()
+        config.read("config/config.ini")
+        policy_file = config["POLICY"]["empty_policy"]
 
-print("Printing raw SBOM tree")
-print_visitor = PrintVisitor()
-sbom_tree.accept(print_visitor)
+        # Parse SPDX data into a Document object
+        SBOM_parser = SBOMParser()
+        SBOM_parser.parse_file(bom_file)
+        # SBOM_parser.parse_file("simple_sbom.json")
+        # Build the tree and compute the root hash
+        sbom = SBOM_parser.sbom
+        sbom_tree = build_sbom_tree(sbom, "", policy_file)
 
-encrypt_visitor = EncryptVisitor("policy")
-sbom_tree.accept(encrypt_visitor)
-print("done encrypting")
+        print_visitor = PrintVisitor()
+        sbom_tree.accept(print_visitor)
 
-merkle_visitor = MerkleVisitor()
-merkle_root_hash = sbom_tree.accept(merkle_visitor)
-# Convert the root hash to a hexadecimal representation for display
-merkle_root_hash_hex = merkle_root_hash.hex()
+        encrypt_visitor = EncryptVisitor("policy")
+        sbom_tree.accept(encrypt_visitor)
 
-print("Printing hashed and encrypted SBOM tree")
-sbom_tree.accept(print_visitor)
+        merkle_visitor = MerkleVisitor()
+        merkle_root_hash = sbom_tree.accept(merkle_visitor)
+        # Convert the root hash to a hexadecimal representation for display
+        merkle_root_hash_hex = merkle_root_hash.hex()
 
-print("Merkle Root Hash for SBOM:", merkle_root_hash_hex)
+        sbom_tree.accept(print_visitor)
+
+        self.assertNotEqual(merkle_root_hash_hex, None)

--- a/privateSBOMExchange/tests/test_package_membership.py
+++ b/privateSBOMExchange/tests/test_package_membership.py
@@ -1,53 +1,59 @@
-"""This tests whether a target has is a member of a tree 
-"""
+"""This tests whether a target has is a member of a tree"""
+
 import copy
+import unittest
 
 from lib4sbom.parser import SBOMParser
 from petra.util.config import Config
 from petra.models import MerkleVisitor, EncryptVisitor, DecryptVisitor
-from petra.models.tree_ops import GetTargetNodes, get_membership_proof, verify_membership_proof,build_sbom_tree
+from petra.models.tree_ops import (
+    GetTargetNodes,
+    get_membership_proof,
+    verify_membership_proof,
+    build_sbom_tree,
+)
 import cpabe
 
-def is_member(root_hash, target_hash, proof):
-    return verify_membership_proof(root_hash, target_hash, proof)
 
-conf = Config("config/log4j-membership-policy.conf")
-sbom_file = conf.get_sbom_files()[0]
-pk, mk = cpabe.cpabe_setup()
-user_attributes= conf.get_cpabe_group('vuln-group')
-time_attributes="epoch:1767744000"
-user_attributes.append(time_attributes)
-sk = cpabe.cpabe_keygen(pk, mk, user_attributes)
+class TestPackageMembership(unittest.TestCase):
+    def test_package_membership_is_properly_stored(self):
+        conf = Config("config/log4j-membership-policy.conf")
+        sbom_file = conf.get_sbom_files()[0]
+        pk, mk = cpabe.cpabe_setup()
+        user_attributes = conf.get_cpabe_group("vuln-group")
+        time_attributes = "epoch:1767744000"
+        user_attributes.append(time_attributes)
+        sk = cpabe.cpabe_keygen(pk, mk, user_attributes)
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(sbom_file) 
+        # Parse SPDX data into a Document object
+        SBOM_parser = SBOMParser()
+        SBOM_parser.parse_file(sbom_file)
 
-# build sbom tree
-sbom=SBOM_parser.sbom
-time_tree="(\"epoch:1767744000\")"
+        # build sbom tree
+        sbom = SBOM_parser.sbom
+        time_tree = '("epoch:1767744000")'
 
-sbom_tree = build_sbom_tree(sbom, time_tree,conf.get_cpabe_policy('vuln-policy'))
+        sbom_tree = build_sbom_tree(
+            sbom, time_tree, conf.get_cpabe_policy("vuln-policy")
+        )
 
-encrypt_visitor = EncryptVisitor(pk)
-sbom_tree.accept(encrypt_visitor)
-print("done encrypting")
+        encrypt_visitor = EncryptVisitor(pk)
+        sbom_tree.accept(encrypt_visitor)
 
-# hash tree nodes
-merkle_visitor = MerkleVisitor()
-merkle_root_hash = sbom_tree.accept(merkle_visitor)
+        # hash tree nodes
+        merkle_visitor = MerkleVisitor()
+        merkle_root_hash = sbom_tree.accept(merkle_visitor)
 
-# decrypt node data
-decrypt_visitor = DecryptVisitor(sk)
-decrypted_tree = copy.deepcopy(sbom_tree)
-decrypted_tree.accept(decrypt_visitor)
-print("done decrypting")
+        # decrypt node data
+        decrypt_visitor = DecryptVisitor(sk)
+        decrypted_tree = copy.deepcopy(sbom_tree)
+        decrypted_tree.accept(decrypt_visitor)
 
-# search for a specific field node in the tree and recompute its hash
-hash_hunter = GetTargetNodes(b"name:log4j-core")
-decrypted_tree.accept(hash_hunter)
-target_hash=hash_hunter.get_target_hash()
+        # search for a specific field node in the tree and recompute its hash
+        hash_hunter = GetTargetNodes(b"name:log4j-core")
+        decrypted_tree.accept(hash_hunter)
+        target_hash = hash_hunter.get_target_hash()
 
-#Get and verify membership proof
-proof = get_membership_proof(sbom_tree, target_hash)
-assert is_member(merkle_root_hash, target_hash, proof) == True
+        # Get and verify membership proof
+        proof = get_membership_proof(sbom_tree, target_hash)
+        self.assertTrue(verify_membership_proof(merkle_root_hash, target_hash, proof))

--- a/privateSBOMExchange/tests/test_tree_serialization.py
+++ b/privateSBOMExchange/tests/test_tree_serialization.py
@@ -1,43 +1,46 @@
 import configparser
+import unittest
 from lib4sbom.parser import SBOMParser
 import json
 
 from petra.util.config import Config
-from petra.models import  MerkleVisitor, SbomNode, PrintVisitor
+from petra.models import MerkleVisitor, SbomNode, PrintVisitor
 from petra.models.tree_ops import serialize_tree, build_sbom_tree
 
-conf = Config("config/bom-only.conf")
-bom_file = conf.get_sbom_files()[0]
 
-config = configparser.ConfigParser()
-config.read('config/config.ini')
-policy_file =  config['POLICY']['empty_policy']
+class TestTreeSerialization(unittest.TestCase):
+    def test_parsed_tree_print(self):
+        conf = Config("config/bom-only.conf")
+        bom_file = conf.get_sbom_files()[0]
 
-# Parse SPDX data into a Document object
-SBOM_parser = SBOMParser()   
-SBOM_parser.parse_file(bom_file)   
+        config = configparser.ConfigParser()
+        config.read("config/config.ini")
+        policy_file = config["POLICY"]["empty_policy"]
 
-# build the test SBOM tree
-sbom=SBOM_parser.sbom
-sbom_tree = build_sbom_tree(sbom,"",policy_file)
+        # Parse SPDX data into a Document object
+        SBOM_parser = SBOMParser()
+        SBOM_parser.parse_file(bom_file)
 
-# hash the tree
-merkle_visitor = MerkleVisitor()
-merkle_root_hash = sbom_tree.accept(merkle_visitor)
+        # build the test SBOM tree
+        sbom = SBOM_parser.sbom
+        sbom_tree = build_sbom_tree(sbom, "", policy_file)
 
-# serialize the tree
-json_tree = json.dumps(serialize_tree(sbom_tree))
+        # hash the tree
+        merkle_visitor = MerkleVisitor()
+        merkle_root_hash = sbom_tree.accept(merkle_visitor)
 
-print(json_tree)
+        # serialize the tree
+        json_tree = json.dumps(serialize_tree(sbom_tree))
 
-# deserialize the tree
-dict_tree = json.loads(json_tree)
+        self.assertNotEqual(json_tree, "")
+        # deserialize the tree
+        dict_tree = json.loads(json_tree)
 
-deser_sbom_tree = SbomNode.from_dict(dict_tree)
+        deser_sbom_tree = SbomNode.from_dict(dict_tree)
 
-# compare hashes here
-assert merkle_root_hash.hex() == deser_sbom_tree.hash.hex()
+        # compare hashes here
+        self.assertEqual(merkle_root_hash.hex(), deser_sbom_tree.hash.hex())
 
-# print the deserialized tree
-print_visitor = PrintVisitor()
-deser_sbom_tree.accept(print_visitor)
+        # print the deserialized tree
+        print_visitor = PrintVisitor()
+        deser_sbom_tree.accept(print_visitor)


### PR DESCRIPTION
The repo currently has a lot of files in tests that *look* like tests but actually aren't in that they don't loudly fail (and/or miss values)

Specifically, the CP-ABE tests are failing for the ParallelVisitor impls, so this also fixes those and offers two variants. One is in the spirit of the paper with an AES pairing whereas the other is the original "pure" CP-ABE.

Note: The KMS requires the Flask server to be running w/ an Internet connection so I didn't go to the trouble of mocking it

Given that `evaluation/` uses the Parallel variants at least sometimes, and what's in the paper is the AES-hybrid, I changed that file, and made a "minimal" CP-ABE version to more clearly demonstrate the issue as just tacking on AES doesn't resolve the mismatching hashes.

Two bugs in the previous parallel visitors implementation are fixed:
  * `visit_sbom_node` now CP-ABE (un)wraps per-policy AES keys correctly, which are used by `SbomNode.plaintext_hash`, and without this the root hash can never be recomputed on decrypt and sameness
    always fails
  * encryption now produces the AES ciphertext eagerly in `finalize` so the caller can hash the redacted tree afterwards (i.e. we actually encrypt)

Note: the per-node AES work is cheap enough (~3 ms for a 600-node SBOM) that a thread/process pool only adds overhead (measured > 4x slower depending on which parallelization approach you pick). I kept the "parallelize" for consistency since we "lost" the Rust version, but it may not be doing anything for us?

"Minimal": The SbomNode fails because `SbomNode.plaintext_hash` brings in the per-policy AES keys but `decrypted_policy` was left empty, i.e. the root was skipped and then the tree can't be verified.

You can verify the failures by just keeping the `tests/` changes and running; trees run under the Parallel case will fail to validate (with the ac17 test being interesting in that the original order means the MerkleVisitor gets a "bad" hash it cant re-verify)